### PR TITLE
Allow ignoring group writable bits

### DIFF
--- a/lib/rubygems/comparator/dir_utils.rb
+++ b/lib/rubygems/comparator/dir_utils.rb
@@ -19,10 +19,6 @@ class Gem::Comparator
       file_first_line(file1) == file_first_line(file2)
     end
 
-    def self.file_permissions(file)
-      sprintf("%o", File.stat(file).mode)
-    end
-
     def self.gem_bin_file?(file)
       file =~ /(\A|.*\/)bin\/.*/
     end

--- a/lib/rubygems/comparator/file_list_comparator.rb
+++ b/lib/rubygems/comparator/file_list_comparator.rb
@@ -15,7 +15,7 @@ class Gem::Comparator
 
   class FileListComparator < Gem::Comparator::Base
 
-    def initialize
+    def initialize(ignore_group_writable=true)
       expect(:packages)
 
       # We need diff
@@ -24,6 +24,8 @@ class Gem::Comparator
       rescue Exception
         error('Calling `diff` command failed. Do you have it installed?')
       end
+
+      @ignore_group_writable = ignore_group_writable
     end
 
     ##
@@ -133,7 +135,7 @@ class Gem::Comparator
 
           #line_changes = lines_changed(prev_file, curr_file)
 
-          changes = Monitor.new_file_permissions(added_file),
+          changes = Monitor.new_file_permissions(added_file, @ignore_group_writable),
                     Monitor.new_file_executability(added_file),
                     Monitor.new_file_shebang(added_file)
 
@@ -157,7 +159,7 @@ class Gem::Comparator
 
           line_changes = Monitor.lines_changed(prev_file, curr_file)
 
-          changes = Monitor.files_permissions_changes(prev_file, curr_file),
+          changes = Monitor.files_permissions_changes(prev_file, curr_file, @ignore_group_writable),
                     Monitor.files_executability_changes(prev_file, curr_file),
                     Monitor.files_shebang_changes(prev_file, curr_file)
 

--- a/test/rubygems/comparator/test_dir_utils.rb
+++ b/test/rubygems/comparator/test_dir_utils.rb
@@ -26,13 +26,6 @@ class TestDirUtils < TestGemModule
     assert_equal false, Gem::Comparator::DirUtils.files_same_first_line?(file1, file3)
   end
 
-  def test_file_permissions
-    file1 = File.join(@v001, 'lib/lorem.rb')
-    file2 = File.join(@v004, 'bin/lorem')
-    assert_equal '100664', Gem::Comparator::DirUtils.file_permissions(file1)
-    assert_equal '100775', Gem::Comparator::DirUtils.file_permissions(file2)
-  end
-
   def test_gem_bin_file
     file1 = File.join(@v001, 'lib/lorem.rb')
     file2 = File.join(@v004, 'bin/lorem')


### PR DESCRIPTION
A lot of gem authors have umask set to 0002 rather than 0022 which the
current code assumes. This change ignores the group writable bit so:

* No flip flop 644 -> 664 warnings
* No unexpected permissions 0664/0775