### PR TITLE
Implement full file diff

### DIFF
--- a/lib/rubygems/commands/compare_command.rb
+++ b/lib/rubygems/commands/compare_command.rb
@@ -40,6 +40,10 @@ class Gem::Commands::CompareCommand < Gem::Command
       options[:param] = 'files'
     end
 
+    add_option('-F', '--diff', 'Diff file contents') do
+      options[:param] = 'diff'
+    end
+
     add_option('-g', '--gemfiles', 'Compare only Gemfiles') do
       options[:param] = 'gemfiles'
     end

--- a/lib/rubygems/comparator.rb
+++ b/lib/rubygems/comparator.rb
@@ -12,6 +12,7 @@ require 'rubygems/comparator/utils'
 require 'rubygems/comparator/report'
 require 'rubygems/comparator/spec_comparator'
 require 'rubygems/comparator/file_list_comparator'
+require 'rubygems/comparator/file_diff_comparator'
 require 'rubygems/comparator/dependency_comparator'
 require 'rubygems/comparator/gemfile_comparator'
 
@@ -88,6 +89,7 @@ class Gem::Comparator
 
     comparators = [SpecComparator,
                    FileListComparator,
+                   FileDiffComparator,
                    DependencyComparator,
                    GemfileComparator]
 

--- a/lib/rubygems/comparator/file_diff_comparator.rb
+++ b/lib/rubygems/comparator/file_diff_comparator.rb
@@ -1,0 +1,190 @@
+require 'diffy'
+require 'rubygems/comparator/base'
+require 'rubygems/comparator/dir_utils'
+require 'rubygems/comparator/monitor'
+
+class Gem::Comparator
+
+  ##
+  # Gem::Comparator::FileDiffComparator can
+  # compare file contents from version of a gem
+  #
+  # To compare the files it needs to extract
+  # gem packages to +options[:output]+
+
+  class FileDiffComparator < Gem::Comparator::Base
+
+    def initialize
+      expect(:packages)
+
+      # We need diff
+      begin
+        IO.popen('diff --version')
+      rescue Exception
+        error('Calling `diff` command failed. Do you have it installed?')
+      end
+    end
+
+    ##
+    # Compare file lists for gem's Gem::Package objects
+    # in +packages+ and writes the changes to the +report+
+    #
+    # If +options[:param]+ is set, it compares only
+    # that file list
+
+    def compare(packages, report, options = {})
+      info 'Checking file lists...'
+
+      @packages = packages
+
+      # Check file lists from older versions to newer
+      filter_params(DIFF_PARAMS, options[:param]).each do |param|
+        all_same = true
+
+        packages.each_with_index do |pkg, index|
+          unpacked_gem_dirs[packages[index].spec.version] = extract_gem(pkg, options[:output])
+          next if index == 0
+
+          # File lists as arrays
+          previous = value_from_spec(:files, packages[index-1].spec)
+          current = value_from_spec(:files, pkg.spec)
+          next unless (previous && current)
+
+          vers = "#{packages[index-1].spec.version}->#{packages[index].spec.version}"
+
+          deleted = previous - current
+          added = current - previous
+          same = current - added
+
+          if options[:brief]
+            deleted, dirs_added = dir_changed(previous, current)
+          end
+
+          report[param].set_header "#{different} #{param}:"
+
+          report[param][vers].section do
+            set_header "#{Rainbow(packages[index-1].spec.version).cyan}->" +
+                       "#{Rainbow(packages[index].spec.version).cyan}:"
+            nest('deleted').section do
+              set_header '* Deleted:'
+              puts deleted unless deleted.empty?
+            end
+
+            nest('added').section do
+              set_header '* Added:'
+              puts dirs_added if options[:brief]
+            end
+          end
+          # Add information about permissions, shebangs etc.
+          report = check_added_files(param, vers, index, added, report, options[:brief])
+
+          report[param][vers]['changed'].set_header '* Changed:'
+          report = check_same_files(param, vers, index, same, report, options[:brief])
+          same_files = report[param][vers]['changed'].messages.empty?
+          all_same = false unless same_files
+
+          if previous == current && same_files && !all_same
+            report[param][vers] << "#{Rainbow(packages[index-1].spec.version).cyan}->" + \
+                                   "#{Rainbow(packages[index].spec.version).cyan}: No change"
+          end
+
+        end
+
+        if all_same && options[:log_all]
+          report[param].set_header "#{same} #{param}:"
+          value = value_from_spec(:files, @packages[0].spec)
+          value = '[]' if value.empty?
+          report[param] << value
+        end
+      end
+      report
+    end
+
+    private
+
+      ##
+      # Access @unpacked_gem_dirs hash that stores
+      # paths to the unpacked gem dirs
+      #
+      # Keys of the hash are gem's versions
+
+      def unpacked_gem_dirs
+        @unpacked_gem_dirs ||= {}
+      end
+
+      ##
+      # This returns [deleted, added] directories between
+      # +previous+ and +current+ file lists
+      #
+      # For top level (.) it compares files themselves
+
+      def dir_changed(previous, current)
+        prev_dirs = DirUtils.dirs_of_files(previous)
+        curr_dirs = DirUtils.dirs_of_files(current)
+        deleted = DirUtils.remove_subdirs(prev_dirs - curr_dirs)
+        added = DirUtils.remove_subdirs(curr_dirs - prev_dirs)
+        [deleted, added]
+      end
+
+      def check_added_files(param, vers, index, files, report, brief_mode)
+        files.each do |file|
+          added_file = File.join(unpacked_gem_dirs[@packages[index].spec.version], file)
+
+          #line_changes = lines_changed(prev_file, curr_file)
+
+          changes = Monitor.new_file_permissions(added_file),
+                    Monitor.new_file_executability(added_file),
+                    Monitor.new_file_shebang(added_file)
+
+          if(!changes.join.empty? || !brief_mode)
+            report[param][vers]['added'] << "#{file}"
+          end
+
+          changes.each do |change|
+            report[param][vers]['added'] << change unless change.empty?
+          end
+        end
+        report
+      end
+
+      def check_same_files(param, vers, index, files, report, brief_mode)
+        files.each do |file|
+          prev_file = File.join(unpacked_gem_dirs[@packages[index-1].spec.version], file)
+          curr_file = File.join(unpacked_gem_dirs[@packages[index].spec.version], file)
+
+          next unless check_files([prev_file, curr_file])
+
+          line_changes = Monitor.files_diff(prev_file, curr_file)
+
+          changes = Monitor.files_permissions_changes(prev_file, curr_file),
+                    Monitor.files_executability_changes(prev_file, curr_file),
+                    Monitor.files_shebang_changes(prev_file, curr_file)
+
+          if(!changes.join.empty? || (!brief_mode && !line_changes.empty?))
+            report[param][vers]['changed'][file].set_header file
+            report[param][vers]['changed'][file] << line_changes.split("\n")
+          end
+
+          changes.each do |change|
+            report[param][vers]['changed'] << change unless change.empty?
+          end
+        end
+        report
+      end
+
+      ##
+      # Check that files exist
+
+      def check_files(files)
+        files.each do |file|
+          unless File.exist? file
+            warn "#{file} mentioned in spec does not exist " +
+                 "in the gem package, skipping check"
+            return false
+          end
+        end
+        true
+      end
+
+  end
+end

--- a/lib/rubygems/comparator/monitor.rb
+++ b/lib/rubygems/comparator/monitor.rb
@@ -26,6 +26,19 @@ class Gem::Comparator
       changes
     end
 
+    def self.files_diff(prev_file, curr_file)
+      changes = ''
+      Diffy::Diff.new(
+        prev_file, curr_file, :source => 'files', :context => 0
+      ).each do |line|
+        case line
+        when /^\+/ then changes << Rainbow(line).green
+        when /^-/ then changes << Rainbow(line).red
+        end
+      end
+      changes
+    end
+
     def self.files_permissions_changes(prev_file, curr_file)
       prev_permissions = DirUtils.file_permissions(prev_file)
       curr_permissions = DirUtils.file_permissions(curr_file)

--- a/lib/rubygems/comparator/utils.rb
+++ b/lib/rubygems/comparator/utils.rb
@@ -39,6 +39,7 @@ class Gem::Comparator
     SPEC_FILES_PARAMS = %w[ files
                             test_files
                             extra_rdoc_files ]
+    DIFF_PARAMS = %w[ diff ]
     DEPENDENCY_PARAMS = %w[ runtime_dependency
                             development_dependency ]
     GEMFILE_PARAMS = %w[ gemfiles ]
@@ -57,6 +58,7 @@ class Gem::Comparator
                          extensions
                          extra_rdoc_files
                          files
+                         diff
                          license
                          licenses
                          metadata
@@ -71,6 +73,7 @@ class Gem::Comparator
       def param_exists?(param)
         (SPEC_PARAMS.include? param) ||
         (SPEC_FILES_PARAMS.include? param) ||
+        (DIFF_PARAMS.include? param) ||
         (DEPENDENCY_PARAMS.include? param) ||
         (GEMFILE_PARAMS.include? param)
       end


### PR DESCRIPTION
I copied the changes from @deckar01's branch at https://github.com/fedora-ruby/gem-compare/compare/master...deckar01:9a59eda

This should fix https://github.com/fedora-ruby/gem-compare/issues/17

> ## Problem
> Since gems can be published with arbitrary content from the developer's machine, some projects require auditing the contents of the gems directly rather than the commits in the source repository. I currently fetch and unpack them, then run `git diff -U0` on them to get the file changes. `gem-compare` automates much of that process, but does not provide detailed insight into code content that changed.
> 
> ```shell
> $ gem compare --files deckar01-task_list 2.0.0 2.0.1
> Fetching: deckar01-task_list-2.0.0.gem (100%)
> Fetching: deckar01-task_list-2.0.1.gem (100%)
> Compared versions: ["2.0.0", "2.0.1"]
>   DIFFERENT files:
>     2.0.0->2.0.1:
>       * Changed:
>             .travis.yml +0/-1
>             app/assets/javascripts/task_list.coffee +1/-8
>             bower.json +1/-1
>             lib/task_list/version.rb +1/-1
>             package.json +1/-1
>             script/bootstrap +1/-1
>             task_list.gemspec +2/-2
>             test/unit/test_updates.coffee +10/-10
> ```
> 
> ## Proposal
> Add an option that outputs the line diff for the unpacked gem directories with syntax highlighting. There is probably a better UX that can be achieved by integrating the diff into the existing report format, but I plan to just call out of `git diff` when I try this on my fork.
> 
> ```diff
> $ gem compare --diff deckar01-task_list 2.0.0 2.0.1
> Fetching: deckar01-task_list-2.0.0.gem (100%)
> Fetching: deckar01-task_list-2.0.1.gem (100%)
> Compared versions: ["2.0.0", "2.0.1"]
> 
> diff --git a/deckar01-task_list-2.0.0/.travis.yml b/deckar01-task_list-2.0.1/.travis.yml
> index 4996b15..0cf6108 100644
> --- a/deckar01-task_list-2.0.0/.travis.yml
> +++ b/deckar01-task_list-2.0.1/.travis.yml
> @@ -8 +7,0 @@ rvm:
> -  - 1.9.3
> diff --git a/deckar01-task_list-2.0.0/app/assets/javascripts/task_list.coffee b/deckar01-task_list-2.0.1/app/assets/javascripts/task_list.coffee
> index 3fad38b..9d6d1f6 100644
> --- a/deckar01-task_list-2.0.0/app/assets/javascripts/task_list.coffee
> +++ b/deckar01-task_list-2.0.1/app/assets/javascripts/task_list.coffee
> @@ -193,8 +193 @@ class TaskList
> -    \s+                     # is followed by whitespace
> -    (?!
> -      \(.*?\)               # is not part of a [foo](url) link
> -    )
> -    (?=                     # and is followed by zero or more links
> -      (?:\[.*?\]\s*(?:\[.*?\]|\(.*?\))\s*)*
> -      (?:[^\[]|$)           # and either a non-link or the end of the string
> -    )
> +    \s                      # is followed by whitespace
> diff --git a/deckar01-task_list-2.0.0/bower.json b/deckar01-task_list-2.0.1/bower.json
> index cf77b36..ae800e6 100644
> --- a/deckar01-task_list-2.0.0/bower.json
> +++ b/deckar01-task_list-2.0.1/bower.json
> @@ -3 +3 @@
> -  "version": "2.0.0",
> +  "version": "2.0.1",
> diff --git a/deckar01-task_list-2.0.0/lib/task_list/version.rb b/deckar01-task_list-2.0.1/lib/task_list/version.rb
> index 87a969f..3f6f80a 100644
> --- a/deckar01-task_list-2.0.0/lib/task_list/version.rb
> +++ b/deckar01-task_list-2.0.1/lib/task_list/version.rb
> @@ -2 +2 @@ class TaskList
> -  VERSION = [2, 0, 0].join('.')
> +  VERSION = [2, 0, 1].join('.')
> ...
> ```