### PR TITLE
replace curb dependency with URI.open

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,7 @@
 PATH
   remote: .
   specs:
-    gem-compare (0.0.7)
-      curb
+    gem-compare (1.0.0)
       diffy
       gemnasium-parser
       json
@@ -11,7 +10,6 @@ PATH
 GEM
   remote: https://www.rubygems.org/
   specs:
-    curb (1.0.0)
     diffy (3.4.0)
     gemnasium-parser (0.1.9)
     json (2.6.1)

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ You can install `gem-compare` as a gem from RubyGems.org:
 $ gem install gem-compare
 ```
 
-You'll also need header files for `curl` to install the `curb` dependency. On Fedora, run:
-
-```bash
-$ sudo dnf install -y libcurl-devel
-```
-
 ## Usage
 
 By default, `gem-compare` compares specified versions of the given gem and includes only changes in the final report. If it's supposed to compare file lists or Gemfiles it will need to download the gems, otherwise it just downloads the specs. If you want to keep the downloaded `.gem` files, use `-k` (as 'keep') option. If you want to see the full report use `-a` (as 'all') switch:

--- a/gem-compare.gemspec
+++ b/gem-compare.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 3.0.0'
   s.required_rubygems_version = '>= 3.0.0'
   s.add_runtime_dependency 'json'
-  s.add_runtime_dependency 'curb'
   s.add_runtime_dependency 'diffy'
   s.add_runtime_dependency 'rainbow'
   s.add_runtime_dependency 'gemnasium-parser'

--- a/lib/rubygems/comparator.rb
+++ b/lib/rubygems/comparator.rb
@@ -1,7 +1,7 @@
 require 'tmpdir'
 require 'rbconfig'
 require 'rainbow'
-require 'curb'
+require 'uri'
 require 'json'
 require 'rubygems/package'
 require 'rubygems/dependency'
@@ -188,11 +188,8 @@ class Gem::Comparator
     end
 
     def remote_gem_versions(gem_name)
-      client = Curl::Easy.new
-      client.url = "https://rubygems.org/api/v1/versions/#{gem_name}.json"
-      client.follow_location = true
-      client.http_get
-      json = JSON.parse(client.body_str)
+      body_str = URI.open("https://rubygems.org/api/v1/versions/#{gem_name}.json").read
+      json = JSON.parse(body_str)
       gems = json.collect { |version| version['number'] }
       info "Upstream versions: #{gems}"
       gems


### PR DESCRIPTION
For those wanting to use gem-compare on JRuby, the curb dependency
is a show stopper as it needs a c extension to use libcurl.
This commit removes the dependency in favor of URI.open().