### PR TITLE
Allow ignoring group writable bits

### DIFF
--- a/lib/rubygems/comparator/dir_utils.rb
+++ b/lib/rubygems/comparator/dir_utils.rb
@@ -19,10 +19,6 @@ class Gem::Comparator
       file_first_line(file1) == file_first_line(file2)
     end
 
-    def self.file_permissions(file)
-      sprintf("%o", File.stat(file).mode)
-    end
-
     def self.gem_bin_file?(file)
       file =~ /(\A|.*\/)bin\/.*/
     end

--- a/lib/rubygems/comparator/file_list_comparator.rb
+++ b/lib/rubygems/comparator/file_list_comparator.rb
@@ -15,7 +15,7 @@ class Gem::Comparator
 
   class FileListComparator < Gem::Comparator::Base
 
-    def initialize
+    def initialize(ignore_group_writable=true)
       expect(:packages)
 
       # We need diff
@@ -24,6 +24,8 @@ class Gem::Comparator
       rescue Exception
         error('Calling `diff` command failed. Do you have it installed?')
       end
+
+      @ignore_group_writable = ignore_group_writable
     end
 
     ##
@@ -137,7 +139,7 @@ class Gem::Comparator
             Monitor.lines_changed(nil, added_file)
           end
 
-          changes = Monitor.new_file_permissions(added_file),
+          changes = Monitor.new_file_permissions(added_file, @ignore_group_writable),
                     Monitor.new_file_executability(added_file),
                     Monitor.new_file_shebang(added_file)
 
@@ -170,7 +172,7 @@ class Gem::Comparator
             Monitor.lines_changed(prev_file, curr_file)
           end
 
-          changes = Monitor.files_permissions_changes(prev_file, curr_file),
+          changes = Monitor.files_permissions_changes(prev_file, curr_file, @ignore_group_writable),
                     Monitor.files_executability_changes(prev_file, curr_file),
                     Monitor.files_shebang_changes(prev_file, curr_file)
 

--- a/lib/rubygems/comparator/monitor.rb
+++ b/lib/rubygems/comparator/monitor.rb
@@ -42,25 +42,30 @@ class Gem::Comparator
       changes
     end
 
-    def self.files_permissions_changes(prev_file, curr_file)
-      prev_permissions = DirUtils.file_permissions(prev_file)
-      curr_permissions = DirUtils.file_permissions(curr_file)
+    def self.files_permissions_changes(prev_file, curr_file, ignore_group_writable=false)
+      prev_permissions = File.stat(prev_file).mode
+      curr_permissions = File.stat(curr_file).mode
 
-      if prev_permissions != curr_permissions
+      diff = prev_permissions ^ curr_permissions
+      diff ^= 020 if ignore_group_writable
+
+      if diff != 0
         "  (!) New permissions: " +
-        "#{prev_permissions} -> #{curr_permissions}"
+        "#{format_permissions(prev_permissions)} -> #{format_permissions(curr_permissions)}"
       else
         ''
       end
     end
 
-    def self.new_file_permissions(file)
-      file_permissions = DirUtils.file_permissions(file)
+    def self.new_file_permissions(file, ignore_group_writable=false)
+      file_permissions = File.stat(file).mode
+      formatted_file_permissions = format_permissions(file_permissions)
 
-      if file_permissions != '100644'
-        unless (DirUtils.gem_bin_file?(file) && file_permissions == '100755')
-          return "  (!) Unexpected permissions: #{file_permissions}"
-        end
+      file_permissions ^= 020 if ignore_group_writable
+
+      unless file_permissions == 0100644 || \
+          (DirUtils.gem_bin_file?(file) && file_permissions == 0100755)
+        return "  (!) Unexpected permissions: #{formatted_file_permissions}"
       end
       ''
     end
@@ -116,6 +121,10 @@ class Gem::Comparator
       else
         ''
       end
+    end
+
+    def self.format_permissions(permissions)
+      sprintf("%o", permissions)
     end
   end
 end

--- a/lib/rubygems/comparator/report.rb
+++ b/lib/rubygems/comparator/report.rb
@@ -104,7 +104,7 @@ class Gem::Comparator
       end
 
       def lines(line_num)
-        all_messages[line_num].data
+        all_messages[line_num]&.data
       end
 
       def nested_messages

--- a/test/rubygems/comparator/test_dir_utils.rb
+++ b/test/rubygems/comparator/test_dir_utils.rb
@@ -26,13 +26,6 @@ class TestDirUtils < TestGemModule
     assert_equal false, Gem::Comparator::DirUtils.files_same_first_line?(file1, file3)
   end
 
-  def test_file_permissions
-    file1 = File.join(@v001, 'lib/lorem.rb')
-    file2 = File.join(@v004, 'bin/lorem')
-    assert_equal '100664', Gem::Comparator::DirUtils.file_permissions(file1)
-    assert_equal '100775', Gem::Comparator::DirUtils.file_permissions(file2)
-  end
-
   def test_gem_bin_file
     file1 = File.join(@v001, 'lib/lorem.rb')
     file2 = File.join(@v004, 'bin/lorem')

--- a/test/rubygems/comparator/test_file_list_comparator.rb
+++ b/test/rubygems/comparator/test_file_list_comparator.rb
@@ -9,10 +9,9 @@ class TestFileListComparator < TestGemComparator
     assert_equal [], @report['files']['0.0.1->0.0.2']['deleted'].messages
     assert_equal [], @report['files']['0.0.1->0.0.2']['updated'].messages
     assert_equal "bin/lorem +3/-0", @report['files']['0.0.2->0.0.3']['added'].lines(1)
-    assert_equal "(!) Unexpected permissions: 100664", @report['files']['0.0.2->0.0.3']['added'].lines(2).strip
-    assert_equal "(!) File is not executable", @report['files']['0.0.2->0.0.3']['added'].lines(3).strip
-    assert_equal "(!) Shebang found: #!/usr/bin/ruby", @report['files']['0.0.2->0.0.3']['added'].lines(4).strip
-    assert_equal "lib/lorem/utils.rb +7/-0", @report['files']['0.0.2->0.0.3']['added'].lines(5).strip
+    assert_equal "(!) File is not executable", @report['files']['0.0.2->0.0.3']['added'].lines(2).strip
+    assert_equal "(!) Shebang found: #!/usr/bin/ruby", @report['files']['0.0.2->0.0.3']['added'].lines(3).strip
+    assert_equal "lib/lorem/utils.rb +7/-0", @report['files']['0.0.2->0.0.3']['added'].lines(4).strip
     assert_equal [], @report['files']['0.0.2->0.0.3']['deleted'].messages
     assert_equal [], @report['files']['0.0.2->0.0.3']['updated'].messages
     assert_equal [], @report['files']['0.0.3->0.0.4']['added'].messages

--- a/test/rubygems/comparator/test_file_list_comparator.rb
+++ b/test/rubygems/comparator/test_file_list_comparator.rb
@@ -12,6 +12,7 @@ class TestFileListComparator < TestGemComparator
     assert_equal "(!) File is not executable", @report['files']['0.0.2->0.0.3']['added'].lines(2).strip
     assert_equal "(!) Shebang found: #!/usr/bin/ruby", @report['files']['0.0.2->0.0.3']['added'].lines(3).strip
     assert_equal "lib/lorem/utils.rb +7/-0", @report['files']['0.0.2->0.0.3']['added'].lines(4).strip
+    assert_nil @report['files']['0.0.2->0.0.3']['added'].lines(6)
     assert_equal [], @report['files']['0.0.2->0.0.3']['deleted'].messages
     assert_equal [], @report['files']['0.0.2->0.0.3']['updated'].messages
     assert_equal [], @report['files']['0.0.3->0.0.4']['added'].messages

--- a/test/rubygems/comparator/test_monitor.rb
+++ b/test/rubygems/comparator/test_monitor.rb
@@ -111,7 +111,7 @@ class TestMonitor < TestGemModule
     file = Tempfile.new
     begin
       File.chmod(0660, file)
-      assert_equal '  (!) Unexpected permissions: 100660', Gem::Comparator::Monitor.new_file_permissions(file, true)
+      assert_equal '  (!) Unexpected permissions: 100660', Gem::Comparator::Monitor.new_file_permissions(file.path, true)
     ensure
       file.unlink
     end

--- a/test/rubygems/comparator/test_monitor.rb
+++ b/test/rubygems/comparator/test_monitor.rb
@@ -51,11 +51,70 @@ class TestMonitor < TestGemModule
     assert_equal '(!) New permissions: 100664 -> 100775', Gem::Comparator::Monitor.files_permissions_changes(file1, file2).strip 
   end
 
+  def test_files_permissions_changes_ignores_group_writable_added
+    file1 = Tempfile.new
+    file2 = Tempfile.new
+    begin
+      File.chmod(0644, file1)
+      File.chmod(0664, file2)
+      assert_equal '', Gem::Comparator::Monitor.files_permissions_changes(file1.path, file2.path, true)
+    ensure
+      file1.unlink
+      file2.unlink
+    end
+  end
+
+  def test_files_permissions_changes_ignores_group_writable_other_changes
+    file1 = Tempfile.new
+    file2 = Tempfile.new
+    begin
+      File.chmod(0644, file1)
+      File.chmod(0660, file2)
+      assert_equal '  (!) New permissions: 100644 -> 100660', Gem::Comparator::Monitor.files_permissions_changes(file1.path, file2.path, true)
+    ensure
+      file1.unlink
+      file2.unlink
+    end
+  end
+
+  def test_files_permissions_changes_ignores_group_writable_removed
+    file1 = Tempfile.new
+    file2 = Tempfile.new
+    begin
+      File.chmod(0664, file1)
+      File.chmod(0644, file2)
+      assert_equal '', Gem::Comparator::Monitor.files_permissions_changes(file1.path, file2.path, true)
+    ensure
+      file1.unlink
+      file2.unlink
+    end
+  end
+
   def test_new_file_permissions
     file1 = File.join(@v004, 'bin/lorem')
     file2 = File.join(@v004, 'lib/lorem.rb')
     assert_equal '(!) Unexpected permissions: 100775', Gem::Comparator::Monitor.new_file_permissions(file1).strip 
     assert_equal '(!) Unexpected permissions: 100664', Gem::Comparator::Monitor.new_file_permissions(file2).strip 
+  end
+
+  def test_new_file_permissions_ignore_group_writable
+    file = Tempfile.new
+    begin
+      File.chmod(0664, file)
+      assert_equal '', Gem::Comparator::Monitor.new_file_permissions(file, true)
+    ensure
+      file.unlink
+    end
+  end
+
+  def test_new_file_permissions_ignore_group_writable_unreadable
+    file = Tempfile.new
+    begin
+      File.chmod(0660, file)
+      assert_equal '  (!) Unexpected permissions: 100660', Gem::Comparator::Monitor.new_file_permissions(file, true)
+    ensure
+      file.unlink
+    end
   end
 
   def test_files_executability_changes


### PR DESCRIPTION
Resurrected https://github.com/fedora-ruby/gem-compare/pull/16 as it sounds like it makes sense to me (builds on #29 for now)

Tests ran here https://github.com/dentarg/gem-compare-1/actions/runs/2605538489