### PR TITLE
Run CI on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
 
 # GitHub Actions notes
 # - outcome in step name so we can see it without having to expand logs


### PR DESCRIPTION
Forgot to enable CI for pull requests in #29

- Skip CI when updating only Markdown files
- With `workflow_dispatch` tests can be started from the Actions UI by maintainers