### PR TITLE
CI: allow truffleruby-head to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - { os: ubuntu-20.04 , ruby: jruby, allow-failure: true }
           - { os: ubuntu-20.04 , ruby: jruby-head }
           - { os: ubuntu-20.04 , ruby: truffleruby }
-          - { os: ubuntu-20.04 , ruby: truffleruby-head }
+          - { os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Don't let truffleruby-head mark CI as failed as it seems unstable.

I tried to reproduce the failure at https://github.com/fedora-ruby/gem-compare/runs/7251489731?check_suite_focus=true#step:5:66 but ran into some other failures instead. I think they happened due to https://github.com/oracle/truffleruby/issues/2690

I'll include them here for posterity:

```
$ docker run --rm -it -v $(pwd):/app -w /app ghcr.io/flavorjones/truffleruby:nightly-slim bash
Unable to find image 'ghcr.io/flavorjones/truffleruby:nightly-slim' locally
nightly-slim: Pulling from flavorjones/truffleruby
68c15fb212c3: Pull complete
a7d870a1256d: Pull complete
631d6ff24983: Pull complete
6dd4ccbb0363: Pull complete
Digest: sha256:97f4726094dee47d3e516c36f2bc0bf3980243017f0aa3d32fab4b1346e4f4ce
Status: Downloaded newer image for ghcr.io/flavorjones/truffleruby:nightly-slim

root@6536ed695d52:/app# ruby -v
truffleruby 22.3.0-dev-e01a7732, like ruby 3.0.3, GraalVM CE Native [x86_64-linux]

root@6536ed695d52:/app# bundle
Warning: the running version of Bundler (2.2.32) is older than the version that created the lockfile (2.3.7). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.7`.
Fetching gem metadata from https://www.rubygems.org/........
Fetching rake 13.0.6
Installing rake 13.0.6
Fetching gemnasium-parser 0.1.9
Fetching diffy 3.4.2
Fetching json 2.6.2
Using bundler 2.2.32
Fetching rainbow 3.1.1
Installing json 2.6.2 with native extensions
Installing rainbow 3.1.1
Installing diffy 3.4.2
Installing gemnasium-parser 0.1.9
Fetching minitest 5.16.1
Fetching stringio 3.0.2
Installing stringio 3.0.2 with native extensions
Installing minitest 5.16.1
Fetching psych 4.0.4
Installing psych 4.0.4 with native extensions
Using gem-compare 1.1.0 from source at `.`
Fetching rdoc 6.4.0
Installing rdoc 6.4.0
Bundle complete! 4 Gemfile dependencies, 11 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

root@6536ed695d52:/app# TESTOPTS='--seed=21501 -v' bundle exec rake
/usr/local/bin/truffleruby -w -I"lib:test" /usr/local/bundle/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/rubygems/comparator/test_dependency_comparator.rb" "test/rubygems/comparator/test_dir_utils.rb" "test/rubygems/comparator/test_file_list_comparator.rb" "test/rubygems/comparator/test_gemfile_comparator.rb" "test/rubygems/comparator/test_monitor.rb" "test/rubygems/comparator/test_report.rb" "test/rubygems/comparator/test_spec_comparator.rb" "test/rubygems/comparator/test_utils.rb" "test/rubygems/test_gem_commands_compare_command.rb" "test/test_helper.rb" --seed=21501 -v
Run options: --seed=21501 -v

# Running:

TestGemComparatorUtils#test_filter_for_brief_mode = 0.00 s = .
TestGemComparatorUtils#test_param_exist? = 0.00 s = .
TestGemComparatorUtils#test_filter_params = 0.00 s = .
TestFileListComparator#test_files_comparison = 1.34 s = F
TestFileListComparator#test_test_files_comparison = 0.74 s = .
TestGemfileComparator#test_gemfile_comparison = 0.74 s = .
TestMonitor#test_files_added_diff = 0.02 s = .
TestMonitor#test_lines_changed = 0.04 s = .
TestMonitor#test_new_file_executability = 0.01 s = F
TestMonitor#test_new_file_shebang = 0.01 s = .
TestMonitor#test_files_executability_changes = 0.01 s = F
TestMonitor#test_files_permissions_changes = 0.01 s = .
TestMonitor#test_files_diff = 0.02 s = .
TestMonitor#test_files_shebang_changes = 0.02 s = .
TestMonitor#test_new_file_permissions = 0.01 s = .
TestMonitor#test_compact_files_diff = 0.02 s = .
TestDirUtils#test_files_same_first_line? = 0.02 s = .
TestDirUtils#test_file_has_shebang? = 0.01 s = .
TestDirUtils#test_remove_subdirs = 0.02 s = .
TestDirUtils#test_dirs_of_files = 0.01 s = .
TestDirUtils#test_gem_bin_file = 0.01 s = .
TestDirUtils#test_file_permissions = 0.01 s = .
TestDirUtils#test_file_first_line = 0.04 s = .
TestGemCommandsCompareCommand#test_execute_no_gemfile = 0.01 s = .
TestGemCommandsCompareCommand#test_execute_no_patch = 0.00 s = .
TestDependencyComparator#test_development_dependencies_comparison = 1.02 s = .
TestDependencyComparator#test_runtime_dependencies_comparison = 0.73 s = .
TestGemComparatorReport#test_all_messages = 0.00 s = .
TestSpecComparator#test_bindir_comparison = 0.69 s = .
TestSpecComparator#test_version_comparison = 0.66 s = .
TestSpecComparator#test_extensions_comparison = 0.62 s = .
TestSpecComparator#test_required_rubygems_version_comparison = 0.63 s = .
TestSpecComparator#test_required_ruby_version_comparison = 0.87 s = .
TestSpecComparator#test_executables_comparison = 0.60 s = .
TestSpecComparator#test_signing_key_comparison = 0.60 s = .
TestSpecComparator#test_post_install_message_comparison = 0.59 s = .
TestSpecComparator#test_platform_comparison = 0.65 s = .
TestSpecComparator#test_email_comparison = 0.54 s = .
TestSpecComparator#test_authors_comparison = 0.60 s = .
TestSpecComparator#test_description_comparison = 0.59 s = .
TestSpecComparator#test_date_comparison = 0.60 s = .
TestSpecComparator#test_cert_chain_comparison = 0.57 s = .
TestSpecComparator#test_rdoc_options_comparison = 0.61 s = .
TestSpecComparator#test_licenses_comparison = 0.87 s = .
TestSpecComparator#test_requirements_comparison = 0.59 s = .
TestSpecComparator#test_metadata_comparison = 0.59 s = .
TestSpecComparator#test_require_paths_comparison = 0.52 s = .
TestSpecComparator#test_summary_comparison = 0.67 s = .
TestSpecComparator#test_rubygems_version_comparison = 0.81 s = .
TestSpecComparator#test_name_comparison = 0.62 s = .
TestSpecComparator#test_homepage_comparison = 0.48 s = .

Finished in 19.594394s, 2.6028 runs/s, 8.9822 assertions/s.

  1) Failure:
TestFileListComparator#test_files_comparison [/app/test/rubygems/comparator/test_file_list_comparator.rb:13]:
--- expected
+++ actual
@@ -1 +1 @@
-"(!) File is not executable"
+"(!) Shebang found: #!/usr/bin/ruby"


  2) Failure:
TestMonitor#test_new_file_executability [/app/test/rubygems/comparator/test_monitor.rb:70]:
Expected: "(!) File is not executable"
  Actual: ""

  3) Failure:
TestMonitor#test_files_executability_changes [/app/test/rubygems/comparator/test_monitor.rb:64]:
Expected: "(!) File is now executable!"
  Actual: ""

51 runs, 176 assertions, 3 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" /usr/local/bundle/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/rubygems/comparator/test_dependency_comparator.rb" "test/rubygems/comparator/test_dir_utils.rb" "test/rubygems/comparator/test_file_list_comparator.rb" "test/rubygems/comparator/test_gemfile_comparator.rb" "test/rubygems/comparator/test_monitor.rb" "test/rubygems/comparator/test_report.rb" "test/rubygems/comparator/test_spec_comparator.rb" "test/rubygems/comparator/test_utils.rb" "test/rubygems/test_gem_commands_compare_command.rb" "test/test_helper.rb" --seed=21501 -v]
/usr/local/bundle/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
<internal:core> core/kernel.rb:376:in `load'
<internal:core> core/kernel.rb:376:in `load'
<internal:core> core/kernel.rb:376:in `load'
<internal:core> core/kernel.rb:376:in `load'
<internal:core> core/kernel.rb:376:in `load'
<internal:core> core/kernel.rb:376:in `load'
/usr/local/bin/bundle:42:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```