### PR TITLE
Use the path returned from `Gem::Source#download`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        ruby: ['3.0', '3.1']
+        os: [ubuntu-24.04]
+        ruby:
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
         include:
-          - { os: ubuntu-20.04 , ruby: ruby-head }
-          - { os: ubuntu-20.04 , ruby: jruby, allow-failure: true }
-          - { os: ubuntu-20.04 , ruby: jruby-head }
-          - { os: ubuntu-20.04 , ruby: truffleruby }
-          - { os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }
+          - { os: ubuntu-24.04 , ruby: ruby-head }
+          - { os: ubuntu-24.04 , ruby: jruby, allow-failure: true }
+          - { os: ubuntu-24.04 , ruby: jruby-head }
+          - { os: ubuntu-24.04 , ruby: truffleruby }
+          - { os: ubuntu-24.04 , ruby: truffleruby-head, allow-failure: true }
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       continue-on-error: ${{ matrix.allow-failure || false }}
       id: bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://www.rubygems.org"
  
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 require 'rdoc/task'
 

--- a/lib/rubygems/commands/compare_command.rb
+++ b/lib/rubygems/commands/compare_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems/command'
 require 'rubygems/version_option'
 require 'rubygems/comparator'

--- a/lib/rubygems/comparator.rb
+++ b/lib/rubygems/comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 require 'rbconfig'
 require 'rainbow'

--- a/lib/rubygems/comparator.rb
+++ b/lib/rubygems/comparator.rb
@@ -225,15 +225,14 @@ class Gem::Comparator
 
     def download_package(gem_name, version)
       spec, source = get_specification(gem_name, version)
-      gem_file = gem_file_name(gem_name, spec.version.to_s)
 
-      Dir.chdir @options[:output] do
+      gem_file_path = Dir.chdir @options[:output] do
         source.download spec
       end
 
-      package = Gem::Package.new File.join(@options[:output], gem_file)
+      package = Gem::Package.new(gem_file_path)
       use_package(package)
-      info "#{gem_file} downloaded."
+      info "#{gem_file_path} downloaded."
 
       package
     end

--- a/lib/rubygems/comparator/base.rb
+++ b/lib/rubygems/comparator/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rainbow'
 require 'rubygems/comparator/utils'
 require 'rubygems/comparator/report'

--- a/lib/rubygems/comparator/dependency_comparator.rb
+++ b/lib/rubygems/comparator/dependency_comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems/comparator/base'
 
 class Gem::Comparator

--- a/lib/rubygems/comparator/dir_utils.rb
+++ b/lib/rubygems/comparator/dir_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 class Gem::Comparator

--- a/lib/rubygems/comparator/file_list_comparator.rb
+++ b/lib/rubygems/comparator/file_list_comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'diffy'
 require 'rubygems/comparator/base'
 require 'rubygems/comparator/dir_utils'

--- a/lib/rubygems/comparator/gemfile_comparator.rb
+++ b/lib/rubygems/comparator/gemfile_comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gemnasium/parser'
 require 'rubygems/comparator/base'
 

--- a/lib/rubygems/comparator/monitor.rb
+++ b/lib/rubygems/comparator/monitor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'diffy'
 require 'rubygems/comparator/base'
 require 'rubygems/comparator/dir_utils'
@@ -15,7 +17,7 @@ class Gem::Comparator
 
     def self.compact_files_diff(prev_file, curr_file)
       prev_file = prev_file.nil? ? Tempfile.new.path : prev_file
-      changes = ''
+      changes = +''
       Diffy::Diff.new(
         prev_file, curr_file, :source => 'files', :context => 0
       ).each do |line|
@@ -29,7 +31,7 @@ class Gem::Comparator
 
     def self.files_diff(prev_file, curr_file)
       prev_file = prev_file.nil? ? Tempfile.new.path : prev_file
-      changes = ''
+      changes = +''
       Diffy::Diff.new(
         prev_file, curr_file, :source => 'files', :context => 0, :include_diff_info => true
       ).each do |line|

--- a/lib/rubygems/comparator/report.rb
+++ b/lib/rubygems/comparator/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems/comparator/report/entry'
 
 class Gem::Comparator

--- a/lib/rubygems/comparator/report/entry.rb
+++ b/lib/rubygems/comparator/report/entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Gem::Comparator
   class Report
     class Entry

--- a/lib/rubygems/comparator/spec_comparator.rb
+++ b/lib/rubygems/comparator/spec_comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems/comparator/base'
 
 class Gem::Comparator

--- a/lib/rubygems/comparator/utils.rb
+++ b/lib/rubygems/comparator/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rainbow'
 require 'rubygems'
 require 'rubygems/user_interaction'

--- a/lib/rubygems/comparator/version.rb
+++ b/lib/rubygems/comparator/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Gem::Comparator
   VERSION = '1.2.1'
 end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'rubygems/command_manager'
 Gem::CommandManager.instance.register_command :compare

--- a/test/rubygems/comparator/test_dependency_comparator.rb
+++ b/test/rubygems/comparator/test_dependency_comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestDependencyComparator < TestGemComparator

--- a/test/rubygems/comparator/test_dir_utils.rb
+++ b/test/rubygems/comparator/test_dir_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestDirUtils < TestGemModule

--- a/test/rubygems/comparator/test_file_list_comparator.rb
+++ b/test/rubygems/comparator/test_file_list_comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestFileListComparator < TestGemComparator

--- a/test/rubygems/comparator/test_gemfile_comparator.rb
+++ b/test/rubygems/comparator/test_gemfile_comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestGemfileComparator < TestGemComparator

--- a/test/rubygems/comparator/test_monitor.rb
+++ b/test/rubygems/comparator/test_monitor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestMonitor < TestGemModule

--- a/test/rubygems/comparator/test_report.rb
+++ b/test/rubygems/comparator/test_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../test_helper'
 require 'rubygems/comparator'
 

--- a/test/rubygems/comparator/test_spec_comparator.rb
+++ b/test/rubygems/comparator/test_spec_comparator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestSpecComparator < TestGemComparator

--- a/test/rubygems/comparator/test_utils.rb
+++ b/test/rubygems/comparator/test_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../test_helper'
 require 'rubygems/comparator'
 

--- a/test/rubygems/mock_gem_ui.rb
+++ b/test/rubygems/mock_gem_ui.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rubygems/user_interaction"
+
+##
+# This Gem::StreamUI subclass records input and output to StringIO for
+# retrieval during tests.
+
+class Gem::MockGemUi < Gem::StreamUI
+  ##
+  # Raised when you haven't provided enough input to your MockGemUi
+
+  class InputEOFError < RuntimeError
+    def initialize(question)
+      super "Out of input for MockGemUi on #{question.inspect}"
+    end
+  end
+
+  class TermError < SystemExit
+    attr_reader :exit_code
+
+    def initialize(exit_code)
+      super
+      @exit_code = exit_code
+    end
+  end
+
+  class SystemExitException < RuntimeError; end
+
+  module TTY
+    attr_accessor :tty
+
+    def tty?
+      @tty = true unless defined?(@tty)
+      @tty
+    end
+
+    def noecho
+      yield self
+    end
+  end
+
+  def initialize(input = "")
+    require "stringio"
+    ins = StringIO.new input
+    outs = StringIO.new
+    errs = StringIO.new
+
+    ins.extend TTY
+    outs.extend TTY
+    errs.extend TTY
+
+    super ins, outs, errs, true
+
+    @terminated = false
+  end
+
+  def ask(question)
+    raise InputEOFError, question if @ins.eof?
+
+    super
+  end
+
+  def input
+    @ins.string
+  end
+
+  def output
+    @outs.string
+  end
+
+  def error
+    @errs.string
+  end
+
+  def terminated?
+    @terminated
+  end
+
+  def terminate_interaction(status=0)
+    @terminated = true
+
+    raise TermError, status if status != 0
+    raise SystemExitException
+  end
+end

--- a/test/rubygems/test_gem_commands_compare_command.rb
+++ b/test/rubygems/test_gem_commands_compare_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../test_helper'
 require_relative 'mock_gem_ui'
 require 'rubygems/user_interaction'

--- a/test/rubygems/test_gem_commands_compare_command.rb
+++ b/test/rubygems/test_gem_commands_compare_command.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
+require_relative 'mock_gem_ui'
 require 'rubygems/user_interaction'
-require 'rubygems/mock_gem_ui'
 require 'rubygems/commands/compare_command'
 
 class TestGemCommandsCompareCommand < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rubygems/comparator'
 


### PR DESCRIPTION
`Gem::SpecFetcher.fetcher.spec_for_dependency` returns
`Gem::Specification`, `Gem::Source` tuples.

https://github.com/fedora-ruby/gem-compare/blob/6b221bcf37b30a9dda05d0a2d7d677bee52ef097/lib/rubygems/comparator.rb#L251

```ruby
irb(main):001> gem_name = "pg"
=> "pg"
irb(main):002> version = "1.6.0"
=> "1.6.0"
irb(main):003> dep = Gem::Dependency.new gem_name, version
=> Gem::Dependency.new("pg", Gem::Requirement.new(["= 1.6.0"]), :runtime)
irb(main):004> specs_and_sources, _errors = Gem::SpecFetcher.fetcher.spec_for_dependency dep
=>
[[[Gem::Specification.new do |s|
...
irb(main):017> specs_and_sources.map { it.map(&:class) }
=> [[Gem::Specification, Gem::Source], [Gem::Specification, Gem::Source]]
```

`Gem::Source#download` will return the local gem file path:

```ruby
irb(main):013> specs_and_sources.first.last.download specs_and_sources.first.first
Fetching pg-1.6.0-aarch64-linux.gem
=> "/app/pg-1.6.0-aarch64-linux.gem"
```

Close https://github.com/fedora-ruby/gem-compare/issues/31